### PR TITLE
Handle custom validation fns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workframe/duff "0.2.0-SNAPSHOT"
+(defproject com.workframe/duff "0.2.1-SNAPSHOT"
   :description "Form state management for re-frame"
   :url         "https://github.com/workframers/rf-forms"
   :license     {:name "Apache License, Version 2.0"


### PR DESCRIPTION
Since duff supports custom validation functions (i.e. functions not created with `fu/make-validation`) differentiation between nil from a custom function and nil from `make-validation` for a field was needed. Hence this is not possible I've made so that `make-validation` for a field always returns a vector; if there are no errors I'm returning an empty vector and then further down the code instead of nil punning we're checking now if the error vector is empty.